### PR TITLE
Fix code scanning alert no. 20: Cross-site scripting

### DIFF
--- a/WebGoat/WebGoatCoins/Autocomplete.ashx.cs
+++ b/WebGoat/WebGoatCoins/Autocomplete.ashx.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Web;
 using System.Data;
+using System.Net;
 using OWASP.WebGoat.NET.App_Code;
 using OWASP.WebGoat.NET.App_Code.DB;
 
@@ -23,9 +24,10 @@ namespace OWASP.WebGoat.NET.WebGoatCoins
             //context.Response.Write("Hello World");
 
             string query = context.Request["query"];
+            string encodedQuery = WebUtility.HtmlEncode(query);
             
-            DataSet ds = du.GetCustomerEmails(query);
-            string json = Encoder.ToJSONSAutocompleteString(query, ds.Tables[0]);
+            DataSet ds = du.GetCustomerEmails(encodedQuery);
+            string json = Encoder.ToJSONSAutocompleteString(encodedQuery, ds.Tables[0]);
 
             if (json != null && json.Length > 0)
             {


### PR DESCRIPTION
Fixes [https://github.com/l-trethewey/ghas-demo-csharp/security/code-scanning/20](https://github.com/l-trethewey/ghas-demo-csharp/security/code-scanning/20)

To fix the problem, we need to ensure that the user-provided input is properly sanitized before being written to the response. The best way to do this is to use the `System.Net.WebUtility.HtmlEncode` method to encode the `query` parameter before it is used in the `Encoder.ToJSONSAutocompleteString` method. This will prevent any malicious input from being executed as code in the user's browser.

1. Import the `System.Net` namespace to use the `WebUtility.HtmlEncode` method.
2. Encode the `query` parameter using `WebUtility.HtmlEncode` before passing it to the `Encoder.ToJSONSAutocompleteString` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
